### PR TITLE
Added support for other relay actions besides toggle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,9 @@ EweAlias
 
 ```
 # Add a relay binding
-EweAddBinding <deviceId>_<button>_<relay>_<actions>_relay
-# Example: EweAddBinding 5AD9E316_1_1_single,double_relay
+EweAddBinding <deviceId>_<button>_<relay>_<actions>_<relayAction>
+# Example: EweAddBinding 5AD9E316_1_1_single,double_toggle
+# Example: EweAddBinding 5AD9E316_1_2_single_0
 
 # Add a dimmer binding
 EweAddBinding <deviceId>_<button>_<channel>_<actions>_dimmer_<step>_<min>_<max>


### PR DESCRIPTION
I wanted to connect 2 R5 devices to R3 Dual, and while original code worked, i found it limiting and not allowing to achieve what I wanted:
1. The only relay action was "toggle", and I wanted buttons on R5 to issue "on" and "off" commands.
2. DeviceId was not present on MQTT payload making it harder to do Json - based Rules in tasmota. 
With above I cold not make 2 R5s working independently, and assigning On and Off to specific buttons o a specific device.

I did these changes. Only the first was essential to achieve my goal, but the other two add robustness.

1. Added support for other relay actions than toggle, via parameter relayAction
2. Added DeviceId to MQTT payload, so actions from multiple remotes can be distinguished
3. Removed dangling div that was messing ewePage on firefox.

BTW, I only updated web UI to display toggle/on/off relay actions, but I did not add controls to set these. Only console command can add On or Off